### PR TITLE
Add quiz with questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,14 @@
 </head>
 <body>
   <div class="container">
-    <h1>FaGe Quiz</h1>
-    <p>Teste dein Wissen rund um die Pflege!</p>
-    <button onclick="startQuiz()">Quiz starten</button>
+    <div class="start">
+      <h1>FaGe Quiz</h1>
+      <p>Teste dein Wissen rund um die Pflege!</p>
+      <button onclick="startQuiz()">Quiz starten</button>
+    </div>
+    <div id="quiz" style="display:none;"></div>
+    <div id="results" style="display:none;"></div>
   </div>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/questions.js
+++ b/questions.js
@@ -1,0 +1,2203 @@
+const questions=[
+  {
+    "frage": "Frage 1: Beispieltext?",
+    "antworten": [
+      "Antwort A1",
+      "Antwort B1",
+      "Antwort C1",
+      "Antwort D1"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 1"
+  },
+  {
+    "frage": "Frage 2: Beispieltext?",
+    "antworten": [
+      "Antwort A2",
+      "Antwort B2",
+      "Antwort C2",
+      "Antwort D2"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 2"
+  },
+  {
+    "frage": "Frage 3: Beispieltext?",
+    "antworten": [
+      "Antwort A3",
+      "Antwort B3",
+      "Antwort C3",
+      "Antwort D3"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 3"
+  },
+  {
+    "frage": "Frage 4: Beispieltext?",
+    "antworten": [
+      "Antwort A4",
+      "Antwort B4",
+      "Antwort C4",
+      "Antwort D4"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 4"
+  },
+  {
+    "frage": "Frage 5: Beispieltext?",
+    "antworten": [
+      "Antwort A5",
+      "Antwort B5",
+      "Antwort C5",
+      "Antwort D5"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 5"
+  },
+  {
+    "frage": "Frage 6: Beispieltext?",
+    "antworten": [
+      "Antwort A6",
+      "Antwort B6",
+      "Antwort C6",
+      "Antwort D6"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 6"
+  },
+  {
+    "frage": "Frage 7: Beispieltext?",
+    "antworten": [
+      "Antwort A7",
+      "Antwort B7",
+      "Antwort C7",
+      "Antwort D7"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 7"
+  },
+  {
+    "frage": "Frage 8: Beispieltext?",
+    "antworten": [
+      "Antwort A8",
+      "Antwort B8",
+      "Antwort C8",
+      "Antwort D8"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 8"
+  },
+  {
+    "frage": "Frage 9: Beispieltext?",
+    "antworten": [
+      "Antwort A9",
+      "Antwort B9",
+      "Antwort C9",
+      "Antwort D9"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 9"
+  },
+  {
+    "frage": "Frage 10: Beispieltext?",
+    "antworten": [
+      "Antwort A10",
+      "Antwort B10",
+      "Antwort C10",
+      "Antwort D10"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 10"
+  },
+  {
+    "frage": "Frage 11: Beispieltext?",
+    "antworten": [
+      "Antwort A11",
+      "Antwort B11",
+      "Antwort C11",
+      "Antwort D11"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 11"
+  },
+  {
+    "frage": "Frage 12: Beispieltext?",
+    "antworten": [
+      "Antwort A12",
+      "Antwort B12",
+      "Antwort C12",
+      "Antwort D12"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 12"
+  },
+  {
+    "frage": "Frage 13: Beispieltext?",
+    "antworten": [
+      "Antwort A13",
+      "Antwort B13",
+      "Antwort C13",
+      "Antwort D13"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 13"
+  },
+  {
+    "frage": "Frage 14: Beispieltext?",
+    "antworten": [
+      "Antwort A14",
+      "Antwort B14",
+      "Antwort C14",
+      "Antwort D14"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 14"
+  },
+  {
+    "frage": "Frage 15: Beispieltext?",
+    "antworten": [
+      "Antwort A15",
+      "Antwort B15",
+      "Antwort C15",
+      "Antwort D15"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 15"
+  },
+  {
+    "frage": "Frage 16: Beispieltext?",
+    "antworten": [
+      "Antwort A16",
+      "Antwort B16",
+      "Antwort C16",
+      "Antwort D16"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 16"
+  },
+  {
+    "frage": "Frage 17: Beispieltext?",
+    "antworten": [
+      "Antwort A17",
+      "Antwort B17",
+      "Antwort C17",
+      "Antwort D17"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 17"
+  },
+  {
+    "frage": "Frage 18: Beispieltext?",
+    "antworten": [
+      "Antwort A18",
+      "Antwort B18",
+      "Antwort C18",
+      "Antwort D18"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 18"
+  },
+  {
+    "frage": "Frage 19: Beispieltext?",
+    "antworten": [
+      "Antwort A19",
+      "Antwort B19",
+      "Antwort C19",
+      "Antwort D19"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 19"
+  },
+  {
+    "frage": "Frage 20: Beispieltext?",
+    "antworten": [
+      "Antwort A20",
+      "Antwort B20",
+      "Antwort C20",
+      "Antwort D20"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 20"
+  },
+  {
+    "frage": "Frage 21: Beispieltext?",
+    "antworten": [
+      "Antwort A21",
+      "Antwort B21",
+      "Antwort C21",
+      "Antwort D21"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 21"
+  },
+  {
+    "frage": "Frage 22: Beispieltext?",
+    "antworten": [
+      "Antwort A22",
+      "Antwort B22",
+      "Antwort C22",
+      "Antwort D22"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 22"
+  },
+  {
+    "frage": "Frage 23: Beispieltext?",
+    "antworten": [
+      "Antwort A23",
+      "Antwort B23",
+      "Antwort C23",
+      "Antwort D23"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 23"
+  },
+  {
+    "frage": "Frage 24: Beispieltext?",
+    "antworten": [
+      "Antwort A24",
+      "Antwort B24",
+      "Antwort C24",
+      "Antwort D24"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 24"
+  },
+  {
+    "frage": "Frage 25: Beispieltext?",
+    "antworten": [
+      "Antwort A25",
+      "Antwort B25",
+      "Antwort C25",
+      "Antwort D25"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 25"
+  },
+  {
+    "frage": "Frage 26: Beispieltext?",
+    "antworten": [
+      "Antwort A26",
+      "Antwort B26",
+      "Antwort C26",
+      "Antwort D26"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 26"
+  },
+  {
+    "frage": "Frage 27: Beispieltext?",
+    "antworten": [
+      "Antwort A27",
+      "Antwort B27",
+      "Antwort C27",
+      "Antwort D27"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 27"
+  },
+  {
+    "frage": "Frage 28: Beispieltext?",
+    "antworten": [
+      "Antwort A28",
+      "Antwort B28",
+      "Antwort C28",
+      "Antwort D28"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 28"
+  },
+  {
+    "frage": "Frage 29: Beispieltext?",
+    "antworten": [
+      "Antwort A29",
+      "Antwort B29",
+      "Antwort C29",
+      "Antwort D29"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 29"
+  },
+  {
+    "frage": "Frage 30: Beispieltext?",
+    "antworten": [
+      "Antwort A30",
+      "Antwort B30",
+      "Antwort C30",
+      "Antwort D30"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 30"
+  },
+  {
+    "frage": "Frage 31: Beispieltext?",
+    "antworten": [
+      "Antwort A31",
+      "Antwort B31",
+      "Antwort C31",
+      "Antwort D31"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 31"
+  },
+  {
+    "frage": "Frage 32: Beispieltext?",
+    "antworten": [
+      "Antwort A32",
+      "Antwort B32",
+      "Antwort C32",
+      "Antwort D32"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 32"
+  },
+  {
+    "frage": "Frage 33: Beispieltext?",
+    "antworten": [
+      "Antwort A33",
+      "Antwort B33",
+      "Antwort C33",
+      "Antwort D33"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 33"
+  },
+  {
+    "frage": "Frage 34: Beispieltext?",
+    "antworten": [
+      "Antwort A34",
+      "Antwort B34",
+      "Antwort C34",
+      "Antwort D34"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 34"
+  },
+  {
+    "frage": "Frage 35: Beispieltext?",
+    "antworten": [
+      "Antwort A35",
+      "Antwort B35",
+      "Antwort C35",
+      "Antwort D35"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 35"
+  },
+  {
+    "frage": "Frage 36: Beispieltext?",
+    "antworten": [
+      "Antwort A36",
+      "Antwort B36",
+      "Antwort C36",
+      "Antwort D36"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 36"
+  },
+  {
+    "frage": "Frage 37: Beispieltext?",
+    "antworten": [
+      "Antwort A37",
+      "Antwort B37",
+      "Antwort C37",
+      "Antwort D37"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 37"
+  },
+  {
+    "frage": "Frage 38: Beispieltext?",
+    "antworten": [
+      "Antwort A38",
+      "Antwort B38",
+      "Antwort C38",
+      "Antwort D38"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 38"
+  },
+  {
+    "frage": "Frage 39: Beispieltext?",
+    "antworten": [
+      "Antwort A39",
+      "Antwort B39",
+      "Antwort C39",
+      "Antwort D39"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 39"
+  },
+  {
+    "frage": "Frage 40: Beispieltext?",
+    "antworten": [
+      "Antwort A40",
+      "Antwort B40",
+      "Antwort C40",
+      "Antwort D40"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 40"
+  },
+  {
+    "frage": "Frage 41: Beispieltext?",
+    "antworten": [
+      "Antwort A41",
+      "Antwort B41",
+      "Antwort C41",
+      "Antwort D41"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 41"
+  },
+  {
+    "frage": "Frage 42: Beispieltext?",
+    "antworten": [
+      "Antwort A42",
+      "Antwort B42",
+      "Antwort C42",
+      "Antwort D42"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 42"
+  },
+  {
+    "frage": "Frage 43: Beispieltext?",
+    "antworten": [
+      "Antwort A43",
+      "Antwort B43",
+      "Antwort C43",
+      "Antwort D43"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 43"
+  },
+  {
+    "frage": "Frage 44: Beispieltext?",
+    "antworten": [
+      "Antwort A44",
+      "Antwort B44",
+      "Antwort C44",
+      "Antwort D44"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 44"
+  },
+  {
+    "frage": "Frage 45: Beispieltext?",
+    "antworten": [
+      "Antwort A45",
+      "Antwort B45",
+      "Antwort C45",
+      "Antwort D45"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 45"
+  },
+  {
+    "frage": "Frage 46: Beispieltext?",
+    "antworten": [
+      "Antwort A46",
+      "Antwort B46",
+      "Antwort C46",
+      "Antwort D46"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 46"
+  },
+  {
+    "frage": "Frage 47: Beispieltext?",
+    "antworten": [
+      "Antwort A47",
+      "Antwort B47",
+      "Antwort C47",
+      "Antwort D47"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 47"
+  },
+  {
+    "frage": "Frage 48: Beispieltext?",
+    "antworten": [
+      "Antwort A48",
+      "Antwort B48",
+      "Antwort C48",
+      "Antwort D48"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 48"
+  },
+  {
+    "frage": "Frage 49: Beispieltext?",
+    "antworten": [
+      "Antwort A49",
+      "Antwort B49",
+      "Antwort C49",
+      "Antwort D49"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 49"
+  },
+  {
+    "frage": "Frage 50: Beispieltext?",
+    "antworten": [
+      "Antwort A50",
+      "Antwort B50",
+      "Antwort C50",
+      "Antwort D50"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 50"
+  },
+  {
+    "frage": "Frage 51: Beispieltext?",
+    "antworten": [
+      "Antwort A51",
+      "Antwort B51",
+      "Antwort C51",
+      "Antwort D51"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 51"
+  },
+  {
+    "frage": "Frage 52: Beispieltext?",
+    "antworten": [
+      "Antwort A52",
+      "Antwort B52",
+      "Antwort C52",
+      "Antwort D52"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 52"
+  },
+  {
+    "frage": "Frage 53: Beispieltext?",
+    "antworten": [
+      "Antwort A53",
+      "Antwort B53",
+      "Antwort C53",
+      "Antwort D53"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 53"
+  },
+  {
+    "frage": "Frage 54: Beispieltext?",
+    "antworten": [
+      "Antwort A54",
+      "Antwort B54",
+      "Antwort C54",
+      "Antwort D54"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 54"
+  },
+  {
+    "frage": "Frage 55: Beispieltext?",
+    "antworten": [
+      "Antwort A55",
+      "Antwort B55",
+      "Antwort C55",
+      "Antwort D55"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 55"
+  },
+  {
+    "frage": "Frage 56: Beispieltext?",
+    "antworten": [
+      "Antwort A56",
+      "Antwort B56",
+      "Antwort C56",
+      "Antwort D56"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 56"
+  },
+  {
+    "frage": "Frage 57: Beispieltext?",
+    "antworten": [
+      "Antwort A57",
+      "Antwort B57",
+      "Antwort C57",
+      "Antwort D57"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 57"
+  },
+  {
+    "frage": "Frage 58: Beispieltext?",
+    "antworten": [
+      "Antwort A58",
+      "Antwort B58",
+      "Antwort C58",
+      "Antwort D58"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 58"
+  },
+  {
+    "frage": "Frage 59: Beispieltext?",
+    "antworten": [
+      "Antwort A59",
+      "Antwort B59",
+      "Antwort C59",
+      "Antwort D59"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 59"
+  },
+  {
+    "frage": "Frage 60: Beispieltext?",
+    "antworten": [
+      "Antwort A60",
+      "Antwort B60",
+      "Antwort C60",
+      "Antwort D60"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 60"
+  },
+  {
+    "frage": "Frage 61: Beispieltext?",
+    "antworten": [
+      "Antwort A61",
+      "Antwort B61",
+      "Antwort C61",
+      "Antwort D61"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 61"
+  },
+  {
+    "frage": "Frage 62: Beispieltext?",
+    "antworten": [
+      "Antwort A62",
+      "Antwort B62",
+      "Antwort C62",
+      "Antwort D62"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 62"
+  },
+  {
+    "frage": "Frage 63: Beispieltext?",
+    "antworten": [
+      "Antwort A63",
+      "Antwort B63",
+      "Antwort C63",
+      "Antwort D63"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 63"
+  },
+  {
+    "frage": "Frage 64: Beispieltext?",
+    "antworten": [
+      "Antwort A64",
+      "Antwort B64",
+      "Antwort C64",
+      "Antwort D64"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 64"
+  },
+  {
+    "frage": "Frage 65: Beispieltext?",
+    "antworten": [
+      "Antwort A65",
+      "Antwort B65",
+      "Antwort C65",
+      "Antwort D65"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 65"
+  },
+  {
+    "frage": "Frage 66: Beispieltext?",
+    "antworten": [
+      "Antwort A66",
+      "Antwort B66",
+      "Antwort C66",
+      "Antwort D66"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 66"
+  },
+  {
+    "frage": "Frage 67: Beispieltext?",
+    "antworten": [
+      "Antwort A67",
+      "Antwort B67",
+      "Antwort C67",
+      "Antwort D67"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 67"
+  },
+  {
+    "frage": "Frage 68: Beispieltext?",
+    "antworten": [
+      "Antwort A68",
+      "Antwort B68",
+      "Antwort C68",
+      "Antwort D68"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 68"
+  },
+  {
+    "frage": "Frage 69: Beispieltext?",
+    "antworten": [
+      "Antwort A69",
+      "Antwort B69",
+      "Antwort C69",
+      "Antwort D69"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 69"
+  },
+  {
+    "frage": "Frage 70: Beispieltext?",
+    "antworten": [
+      "Antwort A70",
+      "Antwort B70",
+      "Antwort C70",
+      "Antwort D70"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 70"
+  },
+  {
+    "frage": "Frage 71: Beispieltext?",
+    "antworten": [
+      "Antwort A71",
+      "Antwort B71",
+      "Antwort C71",
+      "Antwort D71"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 71"
+  },
+  {
+    "frage": "Frage 72: Beispieltext?",
+    "antworten": [
+      "Antwort A72",
+      "Antwort B72",
+      "Antwort C72",
+      "Antwort D72"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 72"
+  },
+  {
+    "frage": "Frage 73: Beispieltext?",
+    "antworten": [
+      "Antwort A73",
+      "Antwort B73",
+      "Antwort C73",
+      "Antwort D73"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 73"
+  },
+  {
+    "frage": "Frage 74: Beispieltext?",
+    "antworten": [
+      "Antwort A74",
+      "Antwort B74",
+      "Antwort C74",
+      "Antwort D74"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 74"
+  },
+  {
+    "frage": "Frage 75: Beispieltext?",
+    "antworten": [
+      "Antwort A75",
+      "Antwort B75",
+      "Antwort C75",
+      "Antwort D75"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 75"
+  },
+  {
+    "frage": "Frage 76: Beispieltext?",
+    "antworten": [
+      "Antwort A76",
+      "Antwort B76",
+      "Antwort C76",
+      "Antwort D76"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 76"
+  },
+  {
+    "frage": "Frage 77: Beispieltext?",
+    "antworten": [
+      "Antwort A77",
+      "Antwort B77",
+      "Antwort C77",
+      "Antwort D77"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 77"
+  },
+  {
+    "frage": "Frage 78: Beispieltext?",
+    "antworten": [
+      "Antwort A78",
+      "Antwort B78",
+      "Antwort C78",
+      "Antwort D78"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 78"
+  },
+  {
+    "frage": "Frage 79: Beispieltext?",
+    "antworten": [
+      "Antwort A79",
+      "Antwort B79",
+      "Antwort C79",
+      "Antwort D79"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 79"
+  },
+  {
+    "frage": "Frage 80: Beispieltext?",
+    "antworten": [
+      "Antwort A80",
+      "Antwort B80",
+      "Antwort C80",
+      "Antwort D80"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 80"
+  },
+  {
+    "frage": "Frage 81: Beispieltext?",
+    "antworten": [
+      "Antwort A81",
+      "Antwort B81",
+      "Antwort C81",
+      "Antwort D81"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 81"
+  },
+  {
+    "frage": "Frage 82: Beispieltext?",
+    "antworten": [
+      "Antwort A82",
+      "Antwort B82",
+      "Antwort C82",
+      "Antwort D82"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 82"
+  },
+  {
+    "frage": "Frage 83: Beispieltext?",
+    "antworten": [
+      "Antwort A83",
+      "Antwort B83",
+      "Antwort C83",
+      "Antwort D83"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 83"
+  },
+  {
+    "frage": "Frage 84: Beispieltext?",
+    "antworten": [
+      "Antwort A84",
+      "Antwort B84",
+      "Antwort C84",
+      "Antwort D84"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 84"
+  },
+  {
+    "frage": "Frage 85: Beispieltext?",
+    "antworten": [
+      "Antwort A85",
+      "Antwort B85",
+      "Antwort C85",
+      "Antwort D85"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 85"
+  },
+  {
+    "frage": "Frage 86: Beispieltext?",
+    "antworten": [
+      "Antwort A86",
+      "Antwort B86",
+      "Antwort C86",
+      "Antwort D86"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 86"
+  },
+  {
+    "frage": "Frage 87: Beispieltext?",
+    "antworten": [
+      "Antwort A87",
+      "Antwort B87",
+      "Antwort C87",
+      "Antwort D87"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 87"
+  },
+  {
+    "frage": "Frage 88: Beispieltext?",
+    "antworten": [
+      "Antwort A88",
+      "Antwort B88",
+      "Antwort C88",
+      "Antwort D88"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 88"
+  },
+  {
+    "frage": "Frage 89: Beispieltext?",
+    "antworten": [
+      "Antwort A89",
+      "Antwort B89",
+      "Antwort C89",
+      "Antwort D89"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 89"
+  },
+  {
+    "frage": "Frage 90: Beispieltext?",
+    "antworten": [
+      "Antwort A90",
+      "Antwort B90",
+      "Antwort C90",
+      "Antwort D90"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 90"
+  },
+  {
+    "frage": "Frage 91: Beispieltext?",
+    "antworten": [
+      "Antwort A91",
+      "Antwort B91",
+      "Antwort C91",
+      "Antwort D91"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 91"
+  },
+  {
+    "frage": "Frage 92: Beispieltext?",
+    "antworten": [
+      "Antwort A92",
+      "Antwort B92",
+      "Antwort C92",
+      "Antwort D92"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 92"
+  },
+  {
+    "frage": "Frage 93: Beispieltext?",
+    "antworten": [
+      "Antwort A93",
+      "Antwort B93",
+      "Antwort C93",
+      "Antwort D93"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 93"
+  },
+  {
+    "frage": "Frage 94: Beispieltext?",
+    "antworten": [
+      "Antwort A94",
+      "Antwort B94",
+      "Antwort C94",
+      "Antwort D94"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 94"
+  },
+  {
+    "frage": "Frage 95: Beispieltext?",
+    "antworten": [
+      "Antwort A95",
+      "Antwort B95",
+      "Antwort C95",
+      "Antwort D95"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 95"
+  },
+  {
+    "frage": "Frage 96: Beispieltext?",
+    "antworten": [
+      "Antwort A96",
+      "Antwort B96",
+      "Antwort C96",
+      "Antwort D96"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 96"
+  },
+  {
+    "frage": "Frage 97: Beispieltext?",
+    "antworten": [
+      "Antwort A97",
+      "Antwort B97",
+      "Antwort C97",
+      "Antwort D97"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 97"
+  },
+  {
+    "frage": "Frage 98: Beispieltext?",
+    "antworten": [
+      "Antwort A98",
+      "Antwort B98",
+      "Antwort C98",
+      "Antwort D98"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 98"
+  },
+  {
+    "frage": "Frage 99: Beispieltext?",
+    "antworten": [
+      "Antwort A99",
+      "Antwort B99",
+      "Antwort C99",
+      "Antwort D99"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 99"
+  },
+  {
+    "frage": "Frage 100: Beispieltext?",
+    "antworten": [
+      "Antwort A100",
+      "Antwort B100",
+      "Antwort C100",
+      "Antwort D100"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 100"
+  },
+  {
+    "frage": "Frage 101: Beispieltext?",
+    "antworten": [
+      "Antwort A101",
+      "Antwort B101",
+      "Antwort C101",
+      "Antwort D101"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 101"
+  },
+  {
+    "frage": "Frage 102: Beispieltext?",
+    "antworten": [
+      "Antwort A102",
+      "Antwort B102",
+      "Antwort C102",
+      "Antwort D102"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 102"
+  },
+  {
+    "frage": "Frage 103: Beispieltext?",
+    "antworten": [
+      "Antwort A103",
+      "Antwort B103",
+      "Antwort C103",
+      "Antwort D103"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 103"
+  },
+  {
+    "frage": "Frage 104: Beispieltext?",
+    "antworten": [
+      "Antwort A104",
+      "Antwort B104",
+      "Antwort C104",
+      "Antwort D104"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 104"
+  },
+  {
+    "frage": "Frage 105: Beispieltext?",
+    "antworten": [
+      "Antwort A105",
+      "Antwort B105",
+      "Antwort C105",
+      "Antwort D105"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 105"
+  },
+  {
+    "frage": "Frage 106: Beispieltext?",
+    "antworten": [
+      "Antwort A106",
+      "Antwort B106",
+      "Antwort C106",
+      "Antwort D106"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 106"
+  },
+  {
+    "frage": "Frage 107: Beispieltext?",
+    "antworten": [
+      "Antwort A107",
+      "Antwort B107",
+      "Antwort C107",
+      "Antwort D107"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 107"
+  },
+  {
+    "frage": "Frage 108: Beispieltext?",
+    "antworten": [
+      "Antwort A108",
+      "Antwort B108",
+      "Antwort C108",
+      "Antwort D108"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 108"
+  },
+  {
+    "frage": "Frage 109: Beispieltext?",
+    "antworten": [
+      "Antwort A109",
+      "Antwort B109",
+      "Antwort C109",
+      "Antwort D109"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 109"
+  },
+  {
+    "frage": "Frage 110: Beispieltext?",
+    "antworten": [
+      "Antwort A110",
+      "Antwort B110",
+      "Antwort C110",
+      "Antwort D110"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 110"
+  },
+  {
+    "frage": "Frage 111: Beispieltext?",
+    "antworten": [
+      "Antwort A111",
+      "Antwort B111",
+      "Antwort C111",
+      "Antwort D111"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 111"
+  },
+  {
+    "frage": "Frage 112: Beispieltext?",
+    "antworten": [
+      "Antwort A112",
+      "Antwort B112",
+      "Antwort C112",
+      "Antwort D112"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 112"
+  },
+  {
+    "frage": "Frage 113: Beispieltext?",
+    "antworten": [
+      "Antwort A113",
+      "Antwort B113",
+      "Antwort C113",
+      "Antwort D113"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 113"
+  },
+  {
+    "frage": "Frage 114: Beispieltext?",
+    "antworten": [
+      "Antwort A114",
+      "Antwort B114",
+      "Antwort C114",
+      "Antwort D114"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 114"
+  },
+  {
+    "frage": "Frage 115: Beispieltext?",
+    "antworten": [
+      "Antwort A115",
+      "Antwort B115",
+      "Antwort C115",
+      "Antwort D115"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 115"
+  },
+  {
+    "frage": "Frage 116: Beispieltext?",
+    "antworten": [
+      "Antwort A116",
+      "Antwort B116",
+      "Antwort C116",
+      "Antwort D116"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 116"
+  },
+  {
+    "frage": "Frage 117: Beispieltext?",
+    "antworten": [
+      "Antwort A117",
+      "Antwort B117",
+      "Antwort C117",
+      "Antwort D117"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 117"
+  },
+  {
+    "frage": "Frage 118: Beispieltext?",
+    "antworten": [
+      "Antwort A118",
+      "Antwort B118",
+      "Antwort C118",
+      "Antwort D118"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 118"
+  },
+  {
+    "frage": "Frage 119: Beispieltext?",
+    "antworten": [
+      "Antwort A119",
+      "Antwort B119",
+      "Antwort C119",
+      "Antwort D119"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 119"
+  },
+  {
+    "frage": "Frage 120: Beispieltext?",
+    "antworten": [
+      "Antwort A120",
+      "Antwort B120",
+      "Antwort C120",
+      "Antwort D120"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 120"
+  },
+  {
+    "frage": "Frage 121: Beispieltext?",
+    "antworten": [
+      "Antwort A121",
+      "Antwort B121",
+      "Antwort C121",
+      "Antwort D121"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 121"
+  },
+  {
+    "frage": "Frage 122: Beispieltext?",
+    "antworten": [
+      "Antwort A122",
+      "Antwort B122",
+      "Antwort C122",
+      "Antwort D122"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 122"
+  },
+  {
+    "frage": "Frage 123: Beispieltext?",
+    "antworten": [
+      "Antwort A123",
+      "Antwort B123",
+      "Antwort C123",
+      "Antwort D123"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 123"
+  },
+  {
+    "frage": "Frage 124: Beispieltext?",
+    "antworten": [
+      "Antwort A124",
+      "Antwort B124",
+      "Antwort C124",
+      "Antwort D124"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 124"
+  },
+  {
+    "frage": "Frage 125: Beispieltext?",
+    "antworten": [
+      "Antwort A125",
+      "Antwort B125",
+      "Antwort C125",
+      "Antwort D125"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 125"
+  },
+  {
+    "frage": "Frage 126: Beispieltext?",
+    "antworten": [
+      "Antwort A126",
+      "Antwort B126",
+      "Antwort C126",
+      "Antwort D126"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 126"
+  },
+  {
+    "frage": "Frage 127: Beispieltext?",
+    "antworten": [
+      "Antwort A127",
+      "Antwort B127",
+      "Antwort C127",
+      "Antwort D127"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 127"
+  },
+  {
+    "frage": "Frage 128: Beispieltext?",
+    "antworten": [
+      "Antwort A128",
+      "Antwort B128",
+      "Antwort C128",
+      "Antwort D128"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 128"
+  },
+  {
+    "frage": "Frage 129: Beispieltext?",
+    "antworten": [
+      "Antwort A129",
+      "Antwort B129",
+      "Antwort C129",
+      "Antwort D129"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 129"
+  },
+  {
+    "frage": "Frage 130: Beispieltext?",
+    "antworten": [
+      "Antwort A130",
+      "Antwort B130",
+      "Antwort C130",
+      "Antwort D130"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 130"
+  },
+  {
+    "frage": "Frage 131: Beispieltext?",
+    "antworten": [
+      "Antwort A131",
+      "Antwort B131",
+      "Antwort C131",
+      "Antwort D131"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 131"
+  },
+  {
+    "frage": "Frage 132: Beispieltext?",
+    "antworten": [
+      "Antwort A132",
+      "Antwort B132",
+      "Antwort C132",
+      "Antwort D132"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 132"
+  },
+  {
+    "frage": "Frage 133: Beispieltext?",
+    "antworten": [
+      "Antwort A133",
+      "Antwort B133",
+      "Antwort C133",
+      "Antwort D133"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 133"
+  },
+  {
+    "frage": "Frage 134: Beispieltext?",
+    "antworten": [
+      "Antwort A134",
+      "Antwort B134",
+      "Antwort C134",
+      "Antwort D134"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 134"
+  },
+  {
+    "frage": "Frage 135: Beispieltext?",
+    "antworten": [
+      "Antwort A135",
+      "Antwort B135",
+      "Antwort C135",
+      "Antwort D135"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 135"
+  },
+  {
+    "frage": "Frage 136: Beispieltext?",
+    "antworten": [
+      "Antwort A136",
+      "Antwort B136",
+      "Antwort C136",
+      "Antwort D136"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 136"
+  },
+  {
+    "frage": "Frage 137: Beispieltext?",
+    "antworten": [
+      "Antwort A137",
+      "Antwort B137",
+      "Antwort C137",
+      "Antwort D137"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 137"
+  },
+  {
+    "frage": "Frage 138: Beispieltext?",
+    "antworten": [
+      "Antwort A138",
+      "Antwort B138",
+      "Antwort C138",
+      "Antwort D138"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 138"
+  },
+  {
+    "frage": "Frage 139: Beispieltext?",
+    "antworten": [
+      "Antwort A139",
+      "Antwort B139",
+      "Antwort C139",
+      "Antwort D139"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 139"
+  },
+  {
+    "frage": "Frage 140: Beispieltext?",
+    "antworten": [
+      "Antwort A140",
+      "Antwort B140",
+      "Antwort C140",
+      "Antwort D140"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 140"
+  },
+  {
+    "frage": "Frage 141: Beispieltext?",
+    "antworten": [
+      "Antwort A141",
+      "Antwort B141",
+      "Antwort C141",
+      "Antwort D141"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 141"
+  },
+  {
+    "frage": "Frage 142: Beispieltext?",
+    "antworten": [
+      "Antwort A142",
+      "Antwort B142",
+      "Antwort C142",
+      "Antwort D142"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 142"
+  },
+  {
+    "frage": "Frage 143: Beispieltext?",
+    "antworten": [
+      "Antwort A143",
+      "Antwort B143",
+      "Antwort C143",
+      "Antwort D143"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 143"
+  },
+  {
+    "frage": "Frage 144: Beispieltext?",
+    "antworten": [
+      "Antwort A144",
+      "Antwort B144",
+      "Antwort C144",
+      "Antwort D144"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 144"
+  },
+  {
+    "frage": "Frage 145: Beispieltext?",
+    "antworten": [
+      "Antwort A145",
+      "Antwort B145",
+      "Antwort C145",
+      "Antwort D145"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 145"
+  },
+  {
+    "frage": "Frage 146: Beispieltext?",
+    "antworten": [
+      "Antwort A146",
+      "Antwort B146",
+      "Antwort C146",
+      "Antwort D146"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 146"
+  },
+  {
+    "frage": "Frage 147: Beispieltext?",
+    "antworten": [
+      "Antwort A147",
+      "Antwort B147",
+      "Antwort C147",
+      "Antwort D147"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 147"
+  },
+  {
+    "frage": "Frage 148: Beispieltext?",
+    "antworten": [
+      "Antwort A148",
+      "Antwort B148",
+      "Antwort C148",
+      "Antwort D148"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 148"
+  },
+  {
+    "frage": "Frage 149: Beispieltext?",
+    "antworten": [
+      "Antwort A149",
+      "Antwort B149",
+      "Antwort C149",
+      "Antwort D149"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 149"
+  },
+  {
+    "frage": "Frage 150: Beispieltext?",
+    "antworten": [
+      "Antwort A150",
+      "Antwort B150",
+      "Antwort C150",
+      "Antwort D150"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 150"
+  },
+  {
+    "frage": "Frage 151: Beispieltext?",
+    "antworten": [
+      "Antwort A151",
+      "Antwort B151",
+      "Antwort C151",
+      "Antwort D151"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 151"
+  },
+  {
+    "frage": "Frage 152: Beispieltext?",
+    "antworten": [
+      "Antwort A152",
+      "Antwort B152",
+      "Antwort C152",
+      "Antwort D152"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 152"
+  },
+  {
+    "frage": "Frage 153: Beispieltext?",
+    "antworten": [
+      "Antwort A153",
+      "Antwort B153",
+      "Antwort C153",
+      "Antwort D153"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 153"
+  },
+  {
+    "frage": "Frage 154: Beispieltext?",
+    "antworten": [
+      "Antwort A154",
+      "Antwort B154",
+      "Antwort C154",
+      "Antwort D154"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 154"
+  },
+  {
+    "frage": "Frage 155: Beispieltext?",
+    "antworten": [
+      "Antwort A155",
+      "Antwort B155",
+      "Antwort C155",
+      "Antwort D155"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 155"
+  },
+  {
+    "frage": "Frage 156: Beispieltext?",
+    "antworten": [
+      "Antwort A156",
+      "Antwort B156",
+      "Antwort C156",
+      "Antwort D156"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 156"
+  },
+  {
+    "frage": "Frage 157: Beispieltext?",
+    "antworten": [
+      "Antwort A157",
+      "Antwort B157",
+      "Antwort C157",
+      "Antwort D157"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 157"
+  },
+  {
+    "frage": "Frage 158: Beispieltext?",
+    "antworten": [
+      "Antwort A158",
+      "Antwort B158",
+      "Antwort C158",
+      "Antwort D158"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 158"
+  },
+  {
+    "frage": "Frage 159: Beispieltext?",
+    "antworten": [
+      "Antwort A159",
+      "Antwort B159",
+      "Antwort C159",
+      "Antwort D159"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 159"
+  },
+  {
+    "frage": "Frage 160: Beispieltext?",
+    "antworten": [
+      "Antwort A160",
+      "Antwort B160",
+      "Antwort C160",
+      "Antwort D160"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 160"
+  },
+  {
+    "frage": "Frage 161: Beispieltext?",
+    "antworten": [
+      "Antwort A161",
+      "Antwort B161",
+      "Antwort C161",
+      "Antwort D161"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 161"
+  },
+  {
+    "frage": "Frage 162: Beispieltext?",
+    "antworten": [
+      "Antwort A162",
+      "Antwort B162",
+      "Antwort C162",
+      "Antwort D162"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 162"
+  },
+  {
+    "frage": "Frage 163: Beispieltext?",
+    "antworten": [
+      "Antwort A163",
+      "Antwort B163",
+      "Antwort C163",
+      "Antwort D163"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 163"
+  },
+  {
+    "frage": "Frage 164: Beispieltext?",
+    "antworten": [
+      "Antwort A164",
+      "Antwort B164",
+      "Antwort C164",
+      "Antwort D164"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 164"
+  },
+  {
+    "frage": "Frage 165: Beispieltext?",
+    "antworten": [
+      "Antwort A165",
+      "Antwort B165",
+      "Antwort C165",
+      "Antwort D165"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 165"
+  },
+  {
+    "frage": "Frage 166: Beispieltext?",
+    "antworten": [
+      "Antwort A166",
+      "Antwort B166",
+      "Antwort C166",
+      "Antwort D166"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 166"
+  },
+  {
+    "frage": "Frage 167: Beispieltext?",
+    "antworten": [
+      "Antwort A167",
+      "Antwort B167",
+      "Antwort C167",
+      "Antwort D167"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 167"
+  },
+  {
+    "frage": "Frage 168: Beispieltext?",
+    "antworten": [
+      "Antwort A168",
+      "Antwort B168",
+      "Antwort C168",
+      "Antwort D168"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 168"
+  },
+  {
+    "frage": "Frage 169: Beispieltext?",
+    "antworten": [
+      "Antwort A169",
+      "Antwort B169",
+      "Antwort C169",
+      "Antwort D169"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 169"
+  },
+  {
+    "frage": "Frage 170: Beispieltext?",
+    "antworten": [
+      "Antwort A170",
+      "Antwort B170",
+      "Antwort C170",
+      "Antwort D170"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 170"
+  },
+  {
+    "frage": "Frage 171: Beispieltext?",
+    "antworten": [
+      "Antwort A171",
+      "Antwort B171",
+      "Antwort C171",
+      "Antwort D171"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 171"
+  },
+  {
+    "frage": "Frage 172: Beispieltext?",
+    "antworten": [
+      "Antwort A172",
+      "Antwort B172",
+      "Antwort C172",
+      "Antwort D172"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 172"
+  },
+  {
+    "frage": "Frage 173: Beispieltext?",
+    "antworten": [
+      "Antwort A173",
+      "Antwort B173",
+      "Antwort C173",
+      "Antwort D173"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 173"
+  },
+  {
+    "frage": "Frage 174: Beispieltext?",
+    "antworten": [
+      "Antwort A174",
+      "Antwort B174",
+      "Antwort C174",
+      "Antwort D174"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 174"
+  },
+  {
+    "frage": "Frage 175: Beispieltext?",
+    "antworten": [
+      "Antwort A175",
+      "Antwort B175",
+      "Antwort C175",
+      "Antwort D175"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 175"
+  },
+  {
+    "frage": "Frage 176: Beispieltext?",
+    "antworten": [
+      "Antwort A176",
+      "Antwort B176",
+      "Antwort C176",
+      "Antwort D176"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 176"
+  },
+  {
+    "frage": "Frage 177: Beispieltext?",
+    "antworten": [
+      "Antwort A177",
+      "Antwort B177",
+      "Antwort C177",
+      "Antwort D177"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 177"
+  },
+  {
+    "frage": "Frage 178: Beispieltext?",
+    "antworten": [
+      "Antwort A178",
+      "Antwort B178",
+      "Antwort C178",
+      "Antwort D178"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 178"
+  },
+  {
+    "frage": "Frage 179: Beispieltext?",
+    "antworten": [
+      "Antwort A179",
+      "Antwort B179",
+      "Antwort C179",
+      "Antwort D179"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 179"
+  },
+  {
+    "frage": "Frage 180: Beispieltext?",
+    "antworten": [
+      "Antwort A180",
+      "Antwort B180",
+      "Antwort C180",
+      "Antwort D180"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 180"
+  },
+  {
+    "frage": "Frage 181: Beispieltext?",
+    "antworten": [
+      "Antwort A181",
+      "Antwort B181",
+      "Antwort C181",
+      "Antwort D181"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 181"
+  },
+  {
+    "frage": "Frage 182: Beispieltext?",
+    "antworten": [
+      "Antwort A182",
+      "Antwort B182",
+      "Antwort C182",
+      "Antwort D182"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 182"
+  },
+  {
+    "frage": "Frage 183: Beispieltext?",
+    "antworten": [
+      "Antwort A183",
+      "Antwort B183",
+      "Antwort C183",
+      "Antwort D183"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 183"
+  },
+  {
+    "frage": "Frage 184: Beispieltext?",
+    "antworten": [
+      "Antwort A184",
+      "Antwort B184",
+      "Antwort C184",
+      "Antwort D184"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 184"
+  },
+  {
+    "frage": "Frage 185: Beispieltext?",
+    "antworten": [
+      "Antwort A185",
+      "Antwort B185",
+      "Antwort C185",
+      "Antwort D185"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 185"
+  },
+  {
+    "frage": "Frage 186: Beispieltext?",
+    "antworten": [
+      "Antwort A186",
+      "Antwort B186",
+      "Antwort C186",
+      "Antwort D186"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 186"
+  },
+  {
+    "frage": "Frage 187: Beispieltext?",
+    "antworten": [
+      "Antwort A187",
+      "Antwort B187",
+      "Antwort C187",
+      "Antwort D187"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 187"
+  },
+  {
+    "frage": "Frage 188: Beispieltext?",
+    "antworten": [
+      "Antwort A188",
+      "Antwort B188",
+      "Antwort C188",
+      "Antwort D188"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 188"
+  },
+  {
+    "frage": "Frage 189: Beispieltext?",
+    "antworten": [
+      "Antwort A189",
+      "Antwort B189",
+      "Antwort C189",
+      "Antwort D189"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 189"
+  },
+  {
+    "frage": "Frage 190: Beispieltext?",
+    "antworten": [
+      "Antwort A190",
+      "Antwort B190",
+      "Antwort C190",
+      "Antwort D190"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 190"
+  },
+  {
+    "frage": "Frage 191: Beispieltext?",
+    "antworten": [
+      "Antwort A191",
+      "Antwort B191",
+      "Antwort C191",
+      "Antwort D191"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 191"
+  },
+  {
+    "frage": "Frage 192: Beispieltext?",
+    "antworten": [
+      "Antwort A192",
+      "Antwort B192",
+      "Antwort C192",
+      "Antwort D192"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 192"
+  },
+  {
+    "frage": "Frage 193: Beispieltext?",
+    "antworten": [
+      "Antwort A193",
+      "Antwort B193",
+      "Antwort C193",
+      "Antwort D193"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 193"
+  },
+  {
+    "frage": "Frage 194: Beispieltext?",
+    "antworten": [
+      "Antwort A194",
+      "Antwort B194",
+      "Antwort C194",
+      "Antwort D194"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 194"
+  },
+  {
+    "frage": "Frage 195: Beispieltext?",
+    "antworten": [
+      "Antwort A195",
+      "Antwort B195",
+      "Antwort C195",
+      "Antwort D195"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 195"
+  },
+  {
+    "frage": "Frage 196: Beispieltext?",
+    "antworten": [
+      "Antwort A196",
+      "Antwort B196",
+      "Antwort C196",
+      "Antwort D196"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 196"
+  },
+  {
+    "frage": "Frage 197: Beispieltext?",
+    "antworten": [
+      "Antwort A197",
+      "Antwort B197",
+      "Antwort C197",
+      "Antwort D197"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 197"
+  },
+  {
+    "frage": "Frage 198: Beispieltext?",
+    "antworten": [
+      "Antwort A198",
+      "Antwort B198",
+      "Antwort C198",
+      "Antwort D198"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 198"
+  },
+  {
+    "frage": "Frage 199: Beispieltext?",
+    "antworten": [
+      "Antwort A199",
+      "Antwort B199",
+      "Antwort C199",
+      "Antwort D199"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 199"
+  },
+  {
+    "frage": "Frage 200: Beispieltext?",
+    "antworten": [
+      "Antwort A200",
+      "Antwort B200",
+      "Antwort C200",
+      "Antwort D200"
+    ],
+    "korrekt": 0,
+    "erklaerung": "Erklärung zu Frage 200"
+  }
+];
+export default questions;

--- a/script.js
+++ b/script.js
@@ -1,3 +1,81 @@
-function startQuiz() {
-  alert("Das Quiz wird bald gestartet. (Hier kannst du später dein Quiz einbauen)");
+import questions from './questions.js';
+
+let quizQuestions = [];
+let currentIndex = 0;
+let score = 0;
+let userAnswers = [];
+
+function shuffle(array) {
+  return array.sort(() => Math.random() - 0.5);
 }
+
+export function startQuiz() {
+  document.querySelector('.start').style.display = 'none';
+  document.getElementById('results').style.display = 'none';
+  quizQuestions = shuffle([...questions]).slice(0, 10);
+  currentIndex = 0;
+  score = 0;
+  userAnswers = [];
+  showQuestion();
+}
+
+function showQuestion() {
+  const q = quizQuestions[currentIndex];
+  const container = document.getElementById('quiz');
+  let html = `<h2>${q.frage}</h2>`;
+  q.antworten.forEach((a, i) => {
+    html += `<label><input type="radio" name="answer" value="${i}"> ${a}</label><br>`;
+  });
+  html += `<button id="next">${currentIndex === quizQuestions.length - 1 ? 'Auswerten' : 'Weiter'}</button>`;
+  container.innerHTML = html;
+  container.style.display = 'block';
+  document.getElementById('next').addEventListener('click', submitAnswer);
+}
+
+function submitAnswer() {
+  const selected = document.querySelector('input[name="answer"]:checked');
+  if (!selected) {
+    alert('Bitte eine Antwort wählen.');
+    return;
+  }
+  const val = parseInt(selected.value, 10);
+  userAnswers.push(val);
+  if (val === quizQuestions[currentIndex].korrekt) {
+    score++;
+  }
+  currentIndex++;
+  if (currentIndex < quizQuestions.length) {
+    showQuestion();
+  } else {
+    showResults();
+  }
+}
+
+function showResults() {
+  const container = document.getElementById('quiz');
+  container.style.display = 'none';
+  const resultDiv = document.getElementById('results');
+  let html = `<h2>Auswertung</h2>`;
+  html += `<p>Du hast ${score} von ${quizQuestions.length} Fragen richtig beantwortet.</p>`;
+  html += '<ol>';
+  quizQuestions.forEach((q, idx) => {
+    const userA = userAnswers[idx];
+    const correct = userA === q.korrekt;
+    html += `<li>${q.frage}<br>` +
+      `Deine Antwort: ${q.antworten[userA] || 'Keine'} - ${correct ? 'Richtig' : 'Falsch'}.<br>` +
+      `Korrekt: ${q.antworten[q.korrekt]}<br>` +
+      `<em>${q.erklaerung}</em></li>`;
+  });
+  html += '</ol><button onclick="restartQuiz()">Nochmal spielen</button>';
+  resultDiv.innerHTML = html;
+  resultDiv.style.display = 'block';
+}
+
+export function restartQuiz() {
+  document.getElementById('results').style.display = 'none';
+  document.querySelector('.start').style.display = 'block';
+}
+
+// make functions available globally for inline handlers
+window.startQuiz = startQuiz;
+window.restartQuiz = restartQuiz;

--- a/style.css
+++ b/style.css
@@ -44,3 +44,14 @@ button {
 button:hover {
   background-color: #125ca1;
 }
+#quiz label {
+  display: block;
+  text-align: left;
+  margin-bottom: 0.5rem;
+}
+#quiz h2 {
+  margin-bottom: 1rem;
+}
+#results ol {
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- create `questions.js` with 200 placeholder questions
- update `index.html` to host start page, quiz, and results sections
- implement quiz logic in `script.js` using the question data
- tweak styles for quiz elements

## Testing
- `node -e "import('./questions.js').then(() => console.log('ok'));" --experimental-modules`

------
https://chatgpt.com/codex/tasks/task_e_686eb7e52fec832fa2a90ce7b2051d95